### PR TITLE
feat: allow Workload Identity Federation for Google connector

### DIFF
--- a/connector/google/google_test.go
+++ b/connector/google/google_test.go
@@ -77,6 +77,28 @@ func tempServiceAccountKey() (string, error) {
 	return fd.Name(), err
 }
 
+func tempWorkloadIdentityFederation() (string, error) {
+	fd, err := os.CreateTemp("", "workload_identity_federation")
+	if err != nil {
+		return "", err
+	}
+	defer fd.Close()
+	err = json.NewEncoder(fd).Encode(map[string]any{
+		"type":                              "external_account",
+		"audience":                          "//iam.googleapis.com/projects/111111111111/locations/global/workloadIdentityPools/aws-pool/providers/aws-provider",
+		"subject_token_type":                "urn:ietf:params:aws:token-type:aws4_request",
+		"service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/sa@my-google-project.iam.gserviceaccount.com:generateAccessToken",
+		"token_url":                         "https://sts.googleapis.com/v1/token",
+		"credential_source": map[string]string{
+			"environment_id":                 "aws1",
+			"region_url":                     "http://169.254.169.254/latest/meta-data/placement/availability-zone",
+			"url":                            "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+			"regional_cred_verification_url": "https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+		},
+	})
+	return fd.Name(), err
+}
+
 func TestOpen(t *testing.T) {
 	ts := testSetup()
 	defer ts.Close()
@@ -181,6 +203,77 @@ func TestGetGroups(t *testing.T) {
 		RedirectURI:        ts.URL + "/callback",
 		Scopes:             []string{"openid", "groups"},
 		DomainToAdminEmail: map[string]string{"*": "admin@dexidp.com"},
+	})
+	assert.Nil(t, err)
+
+	conn.adminSrv[wildcardDomainToAdminEmail], err = admin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(ts.URL))
+	assert.Nil(t, err)
+	type testCase struct {
+		userKey                        string
+		fetchTransitiveGroupMembership bool
+		shouldErr                      bool
+		expectedGroups                 []string
+	}
+
+	for name, testCase := range map[string]testCase{
+		"user1_non_transitive_lookup": {
+			userKey:                        "user_1@dexidp.com",
+			fetchTransitiveGroupMembership: false,
+			shouldErr:                      false,
+			expectedGroups:                 []string{"groups_1@dexidp.com", "groups_2@dexidp.com"},
+		},
+		"user1_transitive_lookup": {
+			userKey:                        "user_1@dexidp.com",
+			fetchTransitiveGroupMembership: true,
+			shouldErr:                      false,
+			expectedGroups:                 []string{"groups_0@dexidp.com", "groups_1@dexidp.com", "groups_2@dexidp.com"},
+		},
+		"user2_non_transitive_lookup": {
+			userKey:                        "user_2@dexidp.com",
+			fetchTransitiveGroupMembership: false,
+			shouldErr:                      false,
+			expectedGroups:                 []string{"groups_1@dexidp.com"},
+		},
+		"user2_transitive_lookup": {
+			userKey:                        "user_2@dexidp.com",
+			fetchTransitiveGroupMembership: true,
+			shouldErr:                      false,
+			expectedGroups:                 []string{"groups_0@dexidp.com", "groups_1@dexidp.com"},
+		},
+	} {
+		testCase := testCase
+		callCounter = map[string]int{}
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			lookup := make(map[string]struct{})
+
+			groups, err := conn.getGroups(testCase.userKey, testCase.fetchTransitiveGroupMembership, lookup)
+			if testCase.shouldErr {
+				assert.NotNil(err)
+			} else {
+				assert.Nil(err)
+			}
+			assert.ElementsMatch(testCase.expectedGroups, groups)
+			t.Logf("[%s] Amount of API calls per userKey: %+v\n", t.Name(), callCounter)
+		})
+	}
+}
+
+func TestGetGroupsWithWorkloadIdentityFederation(t *testing.T) {
+	ts := testSetup()
+	defer ts.Close()
+
+	workloadIdentityFederationFilePath, err := tempWorkloadIdentityFederation()
+	assert.Nil(t, err)
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", workloadIdentityFederationFilePath)
+	conn, err := newConnector(&Config{
+		ClientID:                    "testClient",
+		ClientSecret:                "testSecret",
+		RedirectURI:                 ts.URL + "/callback",
+		Scopes:                      []string{"openid", "groups"},
+		DomainToAdminEmail:          map[string]string{"*": "admin@dexidp.com"},
+		ServiceAccountToImpersonate: "sa-dwd@my-google-project.iam.gserviceaccount.com",
 	})
 	assert.Nil(t, err)
 


### PR DESCRIPTION
* A new Google connector option have been introduced, i.e.,
  `serviceAccountToImpersonate`. If this field is non-empty, it is
  assumed that Workload Identity Federation shall be used, and the
  linked service account needs to be configured for domain-wide
  delegation. Moreover, the service account used for Workload Identity
  Federation must include `Service Account Token Creator` for this
  service account.
* Print some warnings if the configuration is not consistent or erroneous.
* Fix fetching groups to rely on `groups` as scope. In the case `groups`
  is specified as a scope, the oauth authentication call will fail as
  Google doesn't support it. Moreover, as fetching groups requires the
  group directory service, it is enough to assume the existence of this
  service as a prerequisite for the fetch. If `groups` is specified as a
  scope, a warning is printed, instead of erroring out, for backwards
  compatibility reasons.
* When specifying `groups` in the configuration, but no group directory
  service will be created, a warning is printed that the groups
  configuration will be ignored.